### PR TITLE
feature : auditing 기능

### DIFF
--- a/inflearn-back/src/main/java/com/ark/inflearnback/InflearnBackApplication.java
+++ b/inflearn-back/src/main/java/com/ark/inflearnback/InflearnBackApplication.java
@@ -2,8 +2,10 @@ package com.ark.inflearnback;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class InflearnBackApplication {
 
 	public static void main(String[] args) {

--- a/inflearn-back/src/main/java/com/ark/inflearnback/common/BaseTimeEntity.java
+++ b/inflearn-back/src/main/java/com/ark/inflearnback/common/BaseTimeEntity.java
@@ -1,0 +1,23 @@
+package com.ark.inflearnback.common;
+
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+@Getter
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdDate;
+    @LastModifiedDate
+    private LocalDateTime lastModifiedDate;
+}

--- a/inflearn-back/src/main/java/com/ark/inflearnback/domain/category/Category.java
+++ b/inflearn-back/src/main/java/com/ark/inflearnback/domain/category/Category.java
@@ -1,9 +1,7 @@
 package com.ark.inflearnback.domain.category;
 
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import com.ark.inflearnback.common.BaseTimeEntity;
+import lombok.*;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotEmpty;
@@ -15,7 +13,8 @@ import java.util.List;
 @Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Category {
+@AllArgsConstructor
+public class Category extends BaseTimeEntity {
     @Id
     @GeneratedValue
     @NotNull

--- a/inflearn-back/src/main/java/com/ark/inflearnback/domain/course/Course.java
+++ b/inflearn-back/src/main/java/com/ark/inflearnback/domain/course/Course.java
@@ -1,5 +1,6 @@
 package com.ark.inflearnback.domain.course;
 
+import com.ark.inflearnback.common.BaseTimeEntity;
 import com.ark.inflearnback.domain.lecture.Lecture;
 import com.ark.inflearnback.domain.user.User;
 import lombok.*;
@@ -11,7 +12,7 @@ import javax.persistence.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
 @AllArgsConstructor
-public class Course {
+public class Course extends BaseTimeEntity {
 
     @Id @GeneratedValue
     @Column(name = "course_id")

--- a/inflearn-back/src/main/java/com/ark/inflearnback/domain/discount/Discount.java
+++ b/inflearn-back/src/main/java/com/ark/inflearnback/domain/discount/Discount.java
@@ -1,9 +1,7 @@
 package com.ark.inflearnback.domain.discount;
 
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import com.ark.inflearnback.common.BaseTimeEntity;
+import lombok.*;
 import com.ark.inflearnback.domain.lecture.Lecture;
 
 import javax.persistence.*;
@@ -14,7 +12,8 @@ import java.time.LocalDateTime;
 @Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Discount {
+@AllArgsConstructor
+public class Discount extends BaseTimeEntity {
     @Id
     @GeneratedValue
     @NotNull

--- a/inflearn-back/src/main/java/com/ark/inflearnback/domain/hashtag/Hashtag.java
+++ b/inflearn-back/src/main/java/com/ark/inflearnback/domain/hashtag/Hashtag.java
@@ -1,9 +1,7 @@
 package com.ark.inflearnback.domain.hashtag;
 
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import com.ark.inflearnback.common.BaseTimeEntity;
+import lombok.*;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -16,7 +14,8 @@ import javax.validation.constraints.NotNull;
 @Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Hashtag {
+@AllArgsConstructor
+public class Hashtag extends BaseTimeEntity {
     @Id @GeneratedValue
     @NotNull
     @Column(name = "hashtag_id")

--- a/inflearn-back/src/main/java/com/ark/inflearnback/domain/lecture/Lecture.java
+++ b/inflearn-back/src/main/java/com/ark/inflearnback/domain/lecture/Lecture.java
@@ -1,11 +1,9 @@
 package com.ark.inflearnback.domain.lecture;
 
+import com.ark.inflearnback.common.BaseTimeEntity;
 import com.ark.inflearnback.domain.enums.Difficulty;
 import com.ark.inflearnback.domain.user.User;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import com.ark.inflearnback.domain.discount.Discount;
 import com.ark.inflearnback.domain.lectureHashtag.LectureHashtag;
 import com.ark.inflearnback.domain.review.Review;
@@ -22,7 +20,8 @@ import java.util.List;
 @Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Lecture {
+@AllArgsConstructor
+public class Lecture extends BaseTimeEntity {
     @Id
     @GeneratedValue
     @NotNull
@@ -60,7 +59,7 @@ public class Lecture {
     @JoinColumn(name = "user_id")
     private User instructor;
 
-    @OneToMany(mappedBy = "lecture",fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @OneToMany(fetch = FetchType.LAZY)
     private List<Review> reviews = new ArrayList<>();
 
 

--- a/inflearn-back/src/main/java/com/ark/inflearnback/domain/lectureHashtag/LectureHashtag.java
+++ b/inflearn-back/src/main/java/com/ark/inflearnback/domain/lectureHashtag/LectureHashtag.java
@@ -1,9 +1,7 @@
 package com.ark.inflearnback.domain.lectureHashtag;
 
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import com.ark.inflearnback.common.BaseTimeEntity;
+import lombok.*;
 import com.ark.inflearnback.domain.hashtag.Hashtag;
 import com.ark.inflearnback.domain.lecture.Lecture;
 
@@ -16,7 +14,8 @@ import java.util.List;
 @Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class LectureHashtag {
+@AllArgsConstructor
+public class LectureHashtag extends BaseTimeEntity {
     @Id
     @GeneratedValue
     @NotNull

--- a/inflearn-back/src/main/java/com/ark/inflearnback/domain/review/Review.java
+++ b/inflearn-back/src/main/java/com/ark/inflearnback/domain/review/Review.java
@@ -1,10 +1,8 @@
 package com.ark.inflearnback.domain.review;
 
+import com.ark.inflearnback.common.BaseTimeEntity;
 import com.ark.inflearnback.domain.lecture.Lecture;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import com.ark.inflearnback.domain.user.User;
 
 import javax.persistence.*;
@@ -15,7 +13,8 @@ import javax.validation.constraints.NotNull;
 @Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Review {
+@AllArgsConstructor
+public class Review extends BaseTimeEntity {
 
     /** TODO : 엔티티 클래스 생성
      * - User : Reivew = 1 : N (단방향 연관관계)

--- a/inflearn-back/src/main/java/com/ark/inflearnback/domain/user/User.java
+++ b/inflearn-back/src/main/java/com/ark/inflearnback/domain/user/User.java
@@ -1,5 +1,6 @@
 package com.ark.inflearnback.domain.user;
 
+import com.ark.inflearnback.common.BaseTimeEntity;
 import com.ark.inflearnback.domain.course.Course;
 import com.ark.inflearnback.domain.enums.Role;
 import com.ark.inflearnback.domain.lecture.Lecture;
@@ -17,7 +18,7 @@ import java.util.List;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-public class User {
+public class User extends BaseTimeEntity {
 
     @Id @GeneratedValue
     @NotNull

--- a/inflearn-back/src/main/java/com/ark/inflearnback/domain/video/Video.java
+++ b/inflearn-back/src/main/java/com/ark/inflearnback/domain/video/Video.java
@@ -1,10 +1,8 @@
 package com.ark.inflearnback.domain.video;
 
+import com.ark.inflearnback.common.BaseTimeEntity;
 import com.ark.inflearnback.domain.lecture.Lecture;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotBlank;
@@ -14,7 +12,8 @@ import javax.validation.constraints.NotNull;
 @Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Video {
+@AllArgsConstructor
+public class Video extends BaseTimeEntity {
     @Id
     @GeneratedValue
     @NotNull

--- a/inflearn-back/src/main/resources/application.yml
+++ b/inflearn-back/src/main/resources/application.yml
@@ -5,7 +5,7 @@ spring:
     password: 1234
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     properties:
       hibernate:
         # show_sql: true

--- a/inflearn-back/src/test/java/com/ark/inflearnback/auditing/AuditingTest.java
+++ b/inflearn-back/src/test/java/com/ark/inflearnback/auditing/AuditingTest.java
@@ -1,0 +1,35 @@
+package com.ark.inflearnback.auditing;
+
+import com.ark.inflearnback.domain.user.User;
+import com.ark.inflearnback.domain.user.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@SpringBootTest
+@Transactional
+public class AuditingTest {
+    @Autowired
+    UserRepository userRepository;
+
+    @Test
+    @DisplayName("auditing이 적용되는지 생성일을 출력")
+    void jpaAuditing() {
+        User user = User.builder()
+                .name("민철이")
+                .email("smc5236@naver.com")
+                .password("1234")
+                .isSubscribed(true)
+                .build();
+
+        userRepository.save(user);
+
+        Optional<User> result = userRepository.findById(user.getId());
+        User findUser = result.get();
+        System.out.println("findUser.getCreatedDate = " + findUser.getCreatedDate());
+    }
+}


### PR DESCRIPTION
각 엔티티의 `수정일`, `변경일`을 자동으로 관리해주는 `auditing`기능을 추가하였습니다. 각 엔티티에는 생성일, 수정일 칼럼이 추가되며 이를 활용하여 강의가 등록된 날짜, 회원가입한 날짜와 같은 기능을 사용할 수 있게 됩니다.
기능이 정상 동작하는지를 테스트 코드로 작성하여 검증하였습니다.
![image](https://user-images.githubusercontent.com/60773356/130038160-0d1a8150-013e-411a-9bb6-fcd30881ccbb.png)
* 유저를 하나 생성하고 db에 저장한 후 다시 꺼내어 해당 user 엔티티가 생성된 날짜를 출력한 것입니다.


추가로 현재 코드에서 클래스 레벨에서 `@Builder`를 사용하고 있기 때문에 `@AllArgsConstructor`가 없으면 오류가 발생합니다.
이는 추후에 수정이 필요합니다. 이슈에 수정방향을 남겨놨으니 확인해주세요!

그리고 작업 시에 메인 애플리케이션을 한번 돌려보세요. 오류가 있다면 빌드 시점에 오류가 발생할테니까요.
테스트 코드도 작성해보시면 좋을 듯해요.