### PR TITLE
ARK-9 Oauth redirect uri 통일 및 Success시의 default url 명시

### DIFF
--- a/src/main/java/com/ark/inflearnback/domain/security/SecurityConfig.java
+++ b/src/main/java/com/ark/inflearnback/domain/security/SecurityConfig.java
@@ -81,8 +81,11 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 )
 
                 .formLogin().disable()
-                .oauth2Login(login -> login.userInfoEndpoint()
-                        .userService(customOauth2UserService)
+                .oauth2Login(login ->
+                        login.defaultSuccessUrl("/")
+                                .loginProcessingUrl("/api/v1/login/oauth2/*")
+                                .userInfoEndpoint()
+                                .userService(customOauth2UserService)
                 )
 
                 .logout(logout -> logout.logoutUrl("/api/v1/logout")

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,6 +21,7 @@ spring:
           google:
             client-id: ENC(6/Ponyj/US/TvdVEZJfmcsPmvaXwKaeCWyudJyZDkNoTnloH+R4r0dR8MFFrA90SkJag3l4b67WQrIqR9Oz8Y6IK45M9ypW0DMxUGsOFc3rFijwDrAhK2Q==)
             client-secret: ENC(FoXXYeauW6EKov8iMfbE57X8cV9jEf4WSQ+FFmjnNIakgPv768fkng==)
+            redirect-uri: '{baseUrl}/api/v1/login/oauth2/{registrationId}'
             scope: profile, email
 
 logging:


### PR DESCRIPTION
[![ARK-9](https://badgen.net/badge/JIRA/ARK-9/0052CC)](https://jira.company.com/browse/ARK-9) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Ark-inflearn&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

- CORS 설정, URI 설계 일관성을 위해 Oauth2.0 리다이렉트 URI을 변경
- 벤더 추가 (구글, 애플, 페이스북, 카카오, 네이버)