### PR TITLE
hotfix: v0.0.4

### DIFF
--- a/src/main/java/com/ark/inflearnback/configuration/security/SecurityConfiguration.java
+++ b/src/main/java/com/ark/inflearnback/configuration/security/SecurityConfiguration.java
@@ -14,6 +14,7 @@ import com.ark.inflearnback.configuration.security.service.SecurityResourceServi
 import com.ark.inflearnback.configuration.security.service.UsernamePasswordService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -112,7 +113,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
 
-        configuration.setAllowedOrigins(List.of("*"));
+        configuration.setAllowedOriginPatterns(Collections.singletonList("*"));
         configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(List.of("authorization", "content-type", "x-auth-token"));
         configuration.setExposedHeaders(List.of("x-auth-token"));


### PR DESCRIPTION
# Error Message

```shell
When allowCredentials is true, allowedOrigins cannot contain the special value "*" since that cannot be set on the "Access-Control-Allow-Origin" response header. 
To allow credentials to a set of origins, list them explicitly or consider using "allowedOriginPatterns" instead.
```

# Solution

Use `configuration.setAllowedOriginPatterns(Collections.singletonList("*"));` instead of `configuration.setAllowedOrigins(List.of("*"));`